### PR TITLE
[GFTCodeFix]:  Update on src/main/java/works/buddy/samples/codefix.java

### DIFF
--- a/src/main/java/works/buddy/samples/codefix.java
+++ b/src/main/java/works/buddy/samples/codefix.java
@@ -14,7 +14,7 @@ public class CreateFile {
             File myObj = new File("filename.txt");
             if (myObj.createNewFile()) {
                 if (DEBUG) {
-                    logger.log(Level.INFO, () -> "File created: " + myObj.getName());
+                    logger.log(Level.INFO, () -> String.format("File created: %s", myObj.getName()));
                 }
             } else {
                 if (DEBUG) {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 65dac04567de857a61eba45f4a8c04cabb7f7212
                                                **Description:** The modification in this pull request is focused on updating a logging statement to use `String.format` instead of simple string concatenation, which improves readability and consistency.
                                                \n
                                                **Summary:** 
                                                - **File Modified:** src/main/java/works/buddy/samples/codefix.java
                                                - **Detailed Description:** The log statement within the `if (DEBUG)` block was altered. The original code used string concatenation to log the file name: 
    ```java
    logger.log(Level.INFO, () -> "File created: " + myObj.getName());
    ```
    The updated code now uses `String.format` for the same purpose:
    ```java
    logger.log(Level.INFO, () -> String.format("File created: %s", myObj.getName()));
    ```
                                                \n
                                                **Recommendation:** 
                                                - **Code Quality:** This change enhances code readability and consistency. Using `String.format` is generally preferred over string concatenation in logging statements as it makes the code cleaner and potentially reduces the risk of errors in more complex log messages.
                                                - **Testing:** Ensure that the logging output is tested in both `DEBUG` and non-`DEBUG` modes to confirm that the log message appears as expected and no new issues are introduced.
                                                - **Performance:** While the performance difference is negligible for this use case, it's good to note that `String.format` is slightly slower than concatenation. Given this is within a logging statement, the impact is minimal.

                                                (No vulnerabilities were detected or fixed in this change.)